### PR TITLE
Switch block registration to block.json

### DIFF
--- a/acf-custom-blocks.php
+++ b/acf-custom-blocks.php
@@ -27,75 +27,12 @@ function bigboost_enqueue_global_assets() {
     wp_enqueue_script('bigboost-global-js', plugin_dir_url(__FILE__) . 'assets/global.js', array('jquery'), null, true);
 }
 
-// Register ACF Blocks
-add_action('acf/init', 'register_bigboost_acf_blocks');
-function register_bigboost_acf_blocks() {
-
-     // Banner Section Block
-    acf_register_block_type(array(
-        'name'              => 'banner-section',
-        'title'             => __('Banner Section'),
-        'description'       => __('A custom banner section block.'),
-        'render_template'   => plugin_dir_path(__FILE__) . 'blocks/banner-section/banner.php',
-        'category'          => 'bigboost-blocks',
-        'icon'              => 'format-image',
-        'keywords'          => array('banner', 'section', 'header'),
-    ));
-
-     // Quote Block
-    acf_register_block_type(array(
-        'name'              => 'quote-section',
-        'title'             => __('Quote'),
-        'description'       => __('A custom Quote block.'),
-        'render_template'   => plugin_dir_path(__FILE__) . 'blocks/quote-section/quote.php',
-        'category'          => 'bigboost-blocks',
-        'icon'              => 'admin-comments',
-        'keywords'          => array('quote', 'quote'),
-    ));
-
-    // Call to Action Block
-    acf_register_block_type(array(
-        'name'              => 'call-to-action',
-        'title'             => __('Call to Action'),
-        'description'       => __('A custom CTA block.'),
-        'render_template'   => plugin_dir_path(__FILE__) . 'blocks/call-to-action/cta.php',
-        'category'          => 'bigboost-blocks',
-        'icon'              => 'megaphone',
-        'keywords'          => array('cta', 'button'),
-    ));
-
-    // Gallery Block
-    acf_register_block_type(array(
-        'name'              => 'gallery',
-        'title'             => __('Image Gallery'),
-        'description'       => __('A custom image gallery block.'),
-        'render_template'   => plugin_dir_path(__FILE__) . 'blocks/gallery/gallery.php',
-        'category'          => 'bigboost-blocks',
-        'icon'              => 'format-gallery',
-        'keywords'          => array('gallery', 'images'),
-    ));
-
-    // Faq Block
-    acf_register_block_type(array(
-        'name'              => 'faq',
-        'title'             => __('Faq Block'),
-        'description'       => __('A custom Question and Answer block.'),
-        'render_template'   => plugin_dir_path(__FILE__) . 'blocks/faq/faq.php',
-        'category'          => 'bigboost-blocks',
-        'icon'              => 'products',
-        'keywords'          => array('gallery', 'images'),
-    ));
-
-     // Circle Slider Block
-    acf_register_block_type(array(
-        'name'              => 'circle-slider',
-        'title'             => __('Circle Slider Block'),
-        'description'       => __('A custom Question and Answer block.'),
-        'render_template'   => plugin_dir_path(__FILE__) . 'blocks/circle-slider/circle-slider.php',
-        'category'          => 'bigboost-blocks',
-        'icon'              => 'products',
-        'keywords'          => array('gallery', 'images'),
-    ));
+// Register blocks from block.json files
+add_action('init', 'bigboost_register_blocks');
+function bigboost_register_blocks() {
+    foreach (glob(plugin_dir_path(__FILE__) . 'blocks/*/block.json') as $block) {
+        register_block_type($block);
+    }
 }
 
 // Add custom block category

--- a/blocks/banner-section/block.json
+++ b/blocks/banner-section/block.json
@@ -1,0 +1,11 @@
+{
+  "name": "acf/banner-section",
+  "title": "Banner Section",
+  "description": "A custom banner section block.",
+  "category": "bigboost-blocks",
+  "icon": "format-image",
+  "keywords": ["banner", "section", "header"],
+  "acf": {
+    "renderTemplate": "banner.php"
+  }
+}

--- a/blocks/call-to-action/block.json
+++ b/blocks/call-to-action/block.json
@@ -1,0 +1,11 @@
+{
+  "name": "acf/call-to-action",
+  "title": "Call to Action",
+  "description": "A custom CTA block.",
+  "category": "bigboost-blocks",
+  "icon": "megaphone",
+  "keywords": ["cta", "button"],
+  "acf": {
+    "renderTemplate": "cta.php"
+  }
+}

--- a/blocks/circle-slider/block.json
+++ b/blocks/circle-slider/block.json
@@ -1,0 +1,11 @@
+{
+  "name": "acf/circle-slider",
+  "title": "Circle Slider Block",
+  "description": "A custom Question and Answer block.",
+  "category": "bigboost-blocks",
+  "icon": "products",
+  "keywords": ["gallery", "images"],
+  "acf": {
+    "renderTemplate": "circle-slider.php"
+  }
+}

--- a/blocks/faq/block.json
+++ b/blocks/faq/block.json
@@ -1,0 +1,11 @@
+{
+  "name": "acf/faq",
+  "title": "Faq Block",
+  "description": "A custom Question and Answer block.",
+  "category": "bigboost-blocks",
+  "icon": "products",
+  "keywords": ["gallery", "images"],
+  "acf": {
+    "renderTemplate": "faq.php"
+  }
+}

--- a/blocks/gallery/block.json
+++ b/blocks/gallery/block.json
@@ -1,0 +1,11 @@
+{
+  "name": "acf/gallery",
+  "title": "Image Gallery",
+  "description": "A custom image gallery block.",
+  "category": "bigboost-blocks",
+  "icon": "format-gallery",
+  "keywords": ["gallery", "images"],
+  "acf": {
+    "renderTemplate": "gallery.php"
+  }
+}

--- a/blocks/quote-section/block.json
+++ b/blocks/quote-section/block.json
@@ -1,0 +1,11 @@
+{
+  "name": "acf/quote-section",
+  "title": "Quote",
+  "description": "A custom Quote block.",
+  "category": "bigboost-blocks",
+  "icon": "admin-comments",
+  "keywords": ["quote", "quote"],
+  "acf": {
+    "renderTemplate": "quote.php"
+  }
+}


### PR DESCRIPTION
## Summary
- auto-register blocks using metadata
- add `block.json` metadata for all blocks

## Testing
- `php -l acf-custom-blocks.php`
- `for file in blocks/*/*.php; do php -l $file; done`

------
https://chatgpt.com/codex/tasks/task_e_68832a06400c8325bed3ebd56eed85ba

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced several new custom blocks, including Banner Section, Call to Action, Circle Slider, FAQ, Image Gallery, and Quote, all available in the editor for easier content creation.
* **Refactor**
  * Improved block registration to automatically detect and register all available blocks, streamlining the process for future additions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->